### PR TITLE
fix: wire drawing bug fixes (#19)

### DIFF
--- a/Models/Components/Wire.cs
+++ b/Models/Components/Wire.cs
@@ -166,12 +166,12 @@ public class Wire : Component, ICloneable
     public override void Draw(DrawingContext ctx)
     {
         if (points.Count == 0) return;
-        
+
         // Use ghost styling if wire is not committed OR is being edited
         bool useGhostStyling = IsBeingEdited && !IsCommitted;
         var penToUse = useGhostStyling ? ComponentDefaults.GhostWirePen : ComponentDefaults.WirePen;
-        
-        if (points.Count == 1 && points[0] != new Point(-1, -1))
+
+        if (points.Count == 1)
         {
             var brushToUse = useGhostStyling ? ComponentDefaults.GhostTerminalBrush : ComponentDefaults.TerminalBrush;
             ctx.DrawEllipse(brushToUse, null,
@@ -184,11 +184,11 @@ public class Wire : Component, ICloneable
         using (var ctxGeo = polyline.Open())
         {
             bool figureStarted = false;
-            
+
             for (int i = 0; i < points.Count; i++)
             {
                 Point currentPoint = points[i];
-                
+
                 // Break point detected
                 if (currentPoint == new Point(-1, -1))
                 {
@@ -211,7 +211,7 @@ public class Wire : Component, ICloneable
                     ctxGeo.LineTo(currentPoint);
                 }
             }
-            
+
             // End the last figure if it was started
             if (figureStarted)
             {
@@ -219,6 +219,19 @@ public class Wire : Component, ICloneable
             }
         }
         ctx.DrawGeometry(null, penToUse, polyline);
+        
+        for (int i = 0; i < points.Count; i++)
+        {
+            // Draw first point, last point, extension point
+            if (i == 0 || points[i - 1] == new Point(-1, -1) ||
+                (i < points.Count-1 && points[i + 1] == new Point(-1, -1)) ||
+                i == points.Count - 1)
+            {
+                var brushToUse = useGhostStyling ? ComponentDefaults.GhostTerminalBrush : ComponentDefaults.TerminalBrush;
+                ctx.DrawEllipse(brushToUse, null,
+                    points[i], ComponentDefaults.TerminalRadius, ComponentDefaults.TerminalRadius);
+            }
+        }
     }
     
     public override void DrawSelection(DrawingContext ctx)

--- a/Models/PreviewManager.cs
+++ b/Models/PreviewManager.cs
@@ -86,6 +86,7 @@ internal class PreviewManager
         // Commits the WIRE ON DOUBLE-CLICK, or RIGHT-CLICK
         if (wirePreview.Points.Count >= 2 && (point.Properties.IsRightButtonPressed || e.ClickCount >= 2))
         {
+            IsCornerPointAdded = false; // fix: prevent blocking the next wire
             // Snap to grid all points
             for (int i = 0; i < wirePreview.Points.Count - 1; i++)
             {
@@ -268,11 +269,16 @@ internal class PreviewManager
         return new Point(snapX, snapY);
     }
 
-    public void StartWireExtension(Point clickPoint, Wire existingWire,  Simulation simulation)
+    public void StartWireExtension(Canvas canvas, Point clickPoint, Wire existingWire,  Simulation simulation)
     {
+        // if (_previewComponent is Wire wire)
+        // {
+        //     canvas.Children.Remove(wire);
+        // }
         existingWire.IsBeingEdited = true;
         existingWire.IsCommitted = false;
         simulation.Components.Remove(existingWire);
+        canvas.Children.Remove(_previewComponent!);
         _previewComponent = existingWire;
         Wire wirePreview = (Wire)_previewComponent!;
         

--- a/Models/Simulation.cs
+++ b/Models/Simulation.cs
@@ -446,7 +446,7 @@ public partial class Simulation : ObservableObject
                                 return;
                             }
                             Console.WriteLine("Registering Wire Extension...");
-                            _previewManager.StartWireExtension(CurrentMousePos, existingWire, this);
+                            _previewManager.StartWireExtension(_canvas!, CurrentMousePos, existingWire, this);
                             return;
                         }
                     }


### PR DESCRIPTION
fix: wires not commit on the first click

After commiting a wire, the second wire would not commit because the isCornerPointAdded variable was not being reset, fixed it by adding a single line in HandleWireCommit function

fix: redundant ellipses left after wire is deleted

The redundant ellipses were left because they were being added to canvas directly. Removed them from the canvas with one line of code to fix the issue.