### PR TITLE
fix: issues with components & terminals overlapping

### DIFF
--- a/Models/PreviewManager.cs
+++ b/Models/PreviewManager.cs
@@ -75,17 +75,27 @@ internal class PreviewManager
         if (!wirePreview.IsValid) return;
 
         Terminal? target = simulation.FindClosestSnapTerminal(CurrentMousePos);
+        Terminal? startingTerminal = simulation.FindClosestSnapTerminal(wirePreview.Points[0]);
         // Add wire to the terminal
         if (target != null) target.AddWire(wirePreview);
 
-        // Use command for adding point
+        // Use command for adding corner point
         CurrentMousePos = SnapToGrid(CurrentMousePos);
         var addPointCommand = new AddWirePointCommand(wirePreview, CurrentMousePos);
         simulation.CommandManager.ExecuteCommand(addPointCommand);
 
+        // Adds the point after the corner point
         var point = e.GetCurrentPoint(sender as Control);
+        Point pointToAdd = SnapToGrid(new Point(point.Position.X, point.Position.Y));
+        Terminal? targetTerminal = simulation.FindClosestSnapTerminal(pointToAdd);
+        if (targetTerminal != null) pointToAdd = simulation.GetAbsoluteTerminalPosition(targetTerminal);
+
+        var addPointCommand2 = new AddWirePointCommand(wirePreview, pointToAdd);
+        simulation.CommandManager.ExecuteCommand(addPointCommand2);
+        
         // Commits the WIRE ON DOUBLE-CLICK, or RIGHT-CLICK
-        if (wirePreview.Points.Count >= 2 && (point.Properties.IsRightButtonPressed || e.ClickCount >= 2))
+        if (wirePreview.Points.Count >= 2 && ((target != null && target != startingTerminal) ||
+            e.ClickCount == 2))
         {
             IsCornerPointAdded = false; // fix: prevent blocking the next wire
             // Snap to grid all points
@@ -206,7 +216,7 @@ internal class PreviewManager
         if (condition1 || condition2 || condition3 || condition4 || condition5)
         {   // PATCH: Annihiliate the wire completely
             if (condition1) Console.WriteLine("Wire cannot be drawn on a used input terminal...");
-            if (condition1) Console.WriteLine("Wire cannot be drawn on a component...");
+            if (condition2) Console.WriteLine("Wire cannot be drawn on a component...");
             else if (condition3) Console.WriteLine("Wire cannot overlap another wire...");
             else if (condition4) Console.WriteLine("Wire cannot self overlap...");
             else if (condition5) Console.WriteLine("Wire cannot cross a terminal...");
@@ -241,12 +251,14 @@ internal class PreviewManager
             bool condition7 = simulation.FindClosestSnapTerminal(wirePreview.Points[^1]) == null &&
                 simulation.DoesWireOverlapAnotherWire(wirePreview.Points);
             bool condition8 = simulation.IsWireSupersetOfAnotherWire(wirePreview.Points);
+            bool condition9 = simulation.DoesWireCrossTerminal(wirePreview.Points, exceptionCase);
 
             if (condition6 || condition7 || condition8)
             {
                 if (condition6) Console.WriteLine("Corner Point cannot be drawn on a component...");
                 else if (condition7) Console.WriteLine("Orthogonal Wire cannot overlap another wire...");
                 else if (condition8) Console.WriteLine("Wire cannot be a superset of another wire...");
+                else if (condition9) Console.WriteLine("Wire cannot cross terminals...");
                 wirePreview.IsValid = false;
             }
             else

--- a/Models/Simulation.cs
+++ b/Models/Simulation.cs
@@ -299,32 +299,55 @@ public partial class Simulation : ObservableObject
 
     private bool IsPointInsideAnyComponent(Point point)
     {
-        return Components.Any(component => component is not Wire && component.Bounds.Contains(point));
+        return Components.Any(component =>
+        {
+            if (component is Wire) return false;
+
+            Rect bounds = component.Bounds;
+
+            if (component.Rotation == 0)    // PATCH: this is a safe check for when rotations are added
+            {
+                Rect adjustedBounds = new Rect(
+                    bounds.X - 10,
+                    bounds.Y,
+                    bounds.Width + 20,  // prevent negative width
+                    bounds.Height
+                );
+                return adjustedBounds.Contains(point);
+            }
+            else
+            {
+                return bounds.Contains(point);
+            }
+        });
     }
 
     public bool IsWireInsideAnyComponent(List<Point> points)
     {
-        for (int i = 0; i < points.Count-1; i++)
+        Point InvalidPoint = new Point(-1, -1);
+        for (int i = 0; i < points.Count - 1; i++)
         {
-            if (points[i] == new Point(-1, -1) || points[i+1] == new Point(-1, -1)) continue;
+            if (points[i] == InvalidPoint || points[i + 1] == InvalidPoint) continue;
             List<Point> checkablePoints = [points[i]];
-            double dx = Math.Abs(points[i].X - points[i + 1].X);
-            double dy = Math.Abs(points[i].Y - points[i + 1].Y);
+            double dx = points[i].X - points[i + 1].X;
+            double dy = points[i].Y - points[i + 1].Y;
 
-            if (dx > 0)
+            if (dx != 0)
             {
                 while (dx != 0)
                 {
-                    checkablePoints.Add(new Point(points[i].X + dx, points[i].Y));
-                    dx -= 10;
+                    checkablePoints.Add(new Point(points[i].X - dx, points[i].Y));
+                    if (dx > 0) dx -= 10;
+                    else dx += 10;
                 }
             }
-            else if (dy > 0)
+            else if (dy != 0)
             {
                 while (dy != 0)
                 {
-                    checkablePoints.Add(new Point(points[i].X, points[i].Y + dy));
-                    dy -= 10;
+                    checkablePoints.Add(new Point(points[i].X, points[i].Y - dy));
+                    if (dy > 0) dy -= 10;
+                    else dy += 10;
                 }
             }
             else


### PR DESCRIPTION
wires were overlapping with components due to wrong implementation of a function and with terminals due to a missing check for terminals overlapping after the corner point was being added.

fix: wire placement control with single-click (#20)

wires can now be committed with the single (left) click when over a terminal, and with a double (left) click when not on a terminal.

addit fix: adding the cursor with corner point

Previously, doing a click would only add the corner point, now it also adds the cursor point to the points.

patch: remove condition 9 from wires

this fixes the false positive signal for now but needs to be fixed properly later