### PR TITLE
ui: enable panning with zoomBorder, preview setVisible

### DIFF
--- a/src/Services/Singleton/Preview.cs
+++ b/src/Services/Singleton/Preview.cs
@@ -20,20 +20,26 @@ public partial class Preview(SimulationService simulationService, CloningService
     [ObservableProperty]
     private bool _isVisible = false;
 
-    public void UpdatePositionTo(Point position) =>
+    public void UpdatePositionTo(Point position)
+    {
         _simulationService.SnapCollectionToPosition(Objects, position, SavedMouseOffset);
+
+        if (!IsVisible)
+            IsVisible = true;
+    }
 
     public void Drop() => Objects.Clear();
 
-    public void Pick(ComponentViewModel c) => Pick([c]);
+    public void Pick(ComponentViewModel c, bool setVisible = true) => Pick([c], setVisible);
 
-    public void Pick(AvaloniaList<CircuitObjectViewModel> collection)
+    public void Pick(AvaloniaList<CircuitObjectViewModel> collection, bool setVisible = true)
     {
         Objects.Clear();
         Objects.AddRange(collection);
 
-        if (!IsVisible)
+        if (setVisible && !IsVisible)
             IsVisible = true;
+
         foreach (var co in collection)
             co.Opacity = 0.5;
 

--- a/src/ViewModels/Main/CanvasViewModel.cs
+++ b/src/ViewModels/Main/CanvasViewModel.cs
@@ -65,16 +65,8 @@ public partial class CanvasViewModel(
 
     public void OnPointerPressed(object? sender, PointerPressedEventArgs e)
     {
-        if (
-            e.KeyModifiers.HasFlag(KeyModifiers.Control)
-            && e.GetCurrentPoint(sender as Control).Properties.IsLeftButtonPressed
-        )
-        {
-            var zoomBorder = (ZoomBorder)((Visual)sender!).Parent!;
-            _panStart = e.GetPosition(zoomBorder);
-            e.Pointer.Capture(sender as Control);
+        if (e.KeyModifiers.HasFlag(KeyModifiers.Control))
             return;
-        }
 
         if (!e.GetCurrentPoint(sender as Control).Properties.IsLeftButtonPressed)
             return;
@@ -97,30 +89,10 @@ public partial class CanvasViewModel(
 
     public void OnPointerMoved(object? sender, PointerEventArgs e)
     {
-        AppState.MousePosition = _simulationService.SnapPointToGrid(e.GetPosition((Visual)sender!));
-
-        if (
-            e.KeyModifiers.HasFlag(KeyModifiers.Control)
-            && e.GetCurrentPoint(sender as Control).Properties.IsLeftButtonPressed
-            && _panStart is Point start
-        )
-        {
-            var zoomBorder = (ZoomBorder)((Visual)sender!).Parent!;
-            var pos = e.GetPosition(zoomBorder);
-            var m = zoomBorder.Matrix;
-            zoomBorder.SetMatrix(
-                new Matrix(
-                    m.M11,
-                    m.M12,
-                    m.M21,
-                    m.M22,
-                    m.M31 + (pos.X - start.X),
-                    m.M32 + (pos.Y - start.Y)
-                )
-            );
-            _panStart = pos;
+        if (e.KeyModifiers.HasFlag(KeyModifiers.Control))
             return;
-        }
+
+        AppState.MousePosition = _simulationService.SnapPointToGrid(e.GetPosition((Visual)sender!));
 
         e.Handled = true;
 
@@ -139,9 +111,6 @@ public partial class CanvasViewModel(
 
     public void OnPointerReleased(object? sender, PointerReleasedEventArgs e)
     {
-        _panStart = null;
-        e.Pointer.Capture(null);
-
         if (SelectionBox.Exists())
             SelectionBox.Nuke();
 
@@ -152,6 +121,56 @@ public partial class CanvasViewModel(
 
         if (!AppState.EditingAllowed)
             return;
+    }
+
+    public void OnPanPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (
+            !e.KeyModifiers.HasFlag(KeyModifiers.Control)
+            || !e.GetCurrentPoint(sender as Control).Properties.IsLeftButtonPressed
+        )
+            return;
+
+        var zoomBorder = (ZoomBorder)sender!;
+        _panStart = e.GetPosition(zoomBorder);
+        e.Pointer.Capture(zoomBorder);
+        e.Handled = true;
+    }
+
+    public void OnPanPointerMoved(object? sender, PointerEventArgs e)
+    {
+        if (
+            !e.KeyModifiers.HasFlag(KeyModifiers.Control)
+            || !e.GetCurrentPoint(sender as Control).Properties.IsLeftButtonPressed
+            || _panStart is not Point start
+        )
+            return;
+
+        var zoomBorder = (ZoomBorder)sender!;
+        var pos = e.GetPosition(zoomBorder);
+        var m = zoomBorder.Matrix;
+        zoomBorder.SetMatrix(
+            new Matrix(
+                m.M11,
+                m.M12,
+                m.M21,
+                m.M22,
+                m.M31 + (pos.X - start.X),
+                m.M32 + (pos.Y - start.Y)
+            )
+        );
+        _panStart = pos;
+        e.Handled = true;
+    }
+
+    public void OnPanPointerReleased(object? sender, PointerReleasedEventArgs e)
+    {
+        if (_panStart is null)
+            return;
+
+        _panStart = null;
+        e.Pointer.Capture(null);
+        e.Handled = true;
     }
 
     public void OnKeyDown(object? sender, KeyEventArgs e)

--- a/src/ViewModels/Main/LeftSidebarViewModel.cs
+++ b/src/ViewModels/Main/LeftSidebarViewModel.cs
@@ -98,7 +98,7 @@ public partial class LeftSidebarViewModel : ViewModelBase
         gate.Inputs.Add(new());
         gate.Inputs.Add(new());
 
-        _preview.Pick(gate);
+        _preview.Pick(gate, setVisible: false);
     }
 
     [RelayCommand]
@@ -107,7 +107,7 @@ public partial class LeftSidebarViewModel : ViewModelBase
         _selection.UnHighlightAll();
 
         NotGateViewModel gate = new() { Input = new(), Output = new() };
-        _preview.Pick(gate);
+        _preview.Pick(gate, setVisible: false);
     }
 
     [RelayCommand]
@@ -119,7 +119,7 @@ public partial class LeftSidebarViewModel : ViewModelBase
         gate.Inputs.Add(new());
         gate.Inputs.Add(new());
 
-        _preview.Pick(gate);
+        _preview.Pick(gate, setVisible: false);
     }
 
     [RelayCommand]
@@ -131,7 +131,7 @@ public partial class LeftSidebarViewModel : ViewModelBase
         gate.Inputs.Add(new());
         gate.Inputs.Add(new());
 
-        _preview.Pick(gate);
+        _preview.Pick(gate, setVisible: false);
     }
 
     [RelayCommand]
@@ -143,7 +143,7 @@ public partial class LeftSidebarViewModel : ViewModelBase
         gate.Inputs.Add(new());
         gate.Inputs.Add(new());
 
-        _preview.Pick(gate);
+        _preview.Pick(gate, setVisible: false);
     }
 
     [RelayCommand]
@@ -155,7 +155,7 @@ public partial class LeftSidebarViewModel : ViewModelBase
         gate.Inputs.Add(new());
         gate.Inputs.Add(new());
 
-        _preview.Pick(gate);
+        _preview.Pick(gate, setVisible: false);
     }
 
     [RelayCommand]
@@ -167,7 +167,7 @@ public partial class LeftSidebarViewModel : ViewModelBase
         gate.Inputs.Add(new());
         gate.Inputs.Add(new());
 
-        _preview.Pick(gate);
+        _preview.Pick(gate, setVisible: false);
     }
 
     [RelayCommand]
@@ -184,7 +184,7 @@ public partial class LeftSidebarViewModel : ViewModelBase
             Cout = new(),
         };
 
-        _preview.Pick(adder);
+        _preview.Pick(adder, setVisible: false);
     }
 
     [RelayCommand]
@@ -200,7 +200,7 @@ public partial class LeftSidebarViewModel : ViewModelBase
             QBar = new(),
         };
 
-        _preview.Pick(latch);
+        _preview.Pick(latch, setVisible: false);
     }
 
     [RelayCommand]
@@ -218,7 +218,7 @@ public partial class LeftSidebarViewModel : ViewModelBase
             QBar = new(),
         };
 
-        _preview.Pick(ff);
+        _preview.Pick(ff, setVisible: false);
     }
 
     [RelayCommand]
@@ -237,7 +237,7 @@ public partial class LeftSidebarViewModel : ViewModelBase
             QBar = new(),
         };
 
-        _preview.Pick(ff);
+        _preview.Pick(ff, setVisible: false);
     }
 
     [RelayCommand]
@@ -255,7 +255,7 @@ public partial class LeftSidebarViewModel : ViewModelBase
             QBar = new(),
         };
 
-        _preview.Pick(ff);
+        _preview.Pick(ff, setVisible: false);
     }
 
     [RelayCommand]
@@ -273,7 +273,7 @@ public partial class LeftSidebarViewModel : ViewModelBase
         reg.AddBit();
         reg.AddBit();
 
-        _preview.Pick(reg);
+        _preview.Pick(reg, setVisible: false);
     }
 
     [RelayCommand]
@@ -293,7 +293,7 @@ public partial class LeftSidebarViewModel : ViewModelBase
         counter.AddBit();
         counter.AddBit();
 
-        _preview.Pick(counter);
+        _preview.Pick(counter, setVisible: false);
     }
 
     [RelayCommand]
@@ -305,7 +305,7 @@ public partial class LeftSidebarViewModel : ViewModelBase
         mux.AddSelectLine();
         mux.AddSelectLine();
 
-        _preview.Pick(mux);
+        _preview.Pick(mux, setVisible: false);
     }
 
     [RelayCommand]
@@ -317,7 +317,7 @@ public partial class LeftSidebarViewModel : ViewModelBase
         demux.AddSelectLine();
         demux.AddSelectLine();
 
-        _preview.Pick(demux);
+        _preview.Pick(demux, setVisible: false);
     }
 
     [RelayCommand]
@@ -329,7 +329,7 @@ public partial class LeftSidebarViewModel : ViewModelBase
         decoder.AddSelectLine();
         decoder.AddSelectLine();
 
-        _preview.Pick(decoder);
+        _preview.Pick(decoder, setVisible: false);
     }
 
     [RelayCommand]
@@ -341,7 +341,7 @@ public partial class LeftSidebarViewModel : ViewModelBase
         encoder.AddSelectLine();
         encoder.AddSelectLine();
 
-        _preview.Pick(encoder);
+        _preview.Pick(encoder, setVisible: false);
     }
 
     [RelayCommand]
@@ -350,7 +350,7 @@ public partial class LeftSidebarViewModel : ViewModelBase
         _selection.UnHighlightAll();
 
         ToggleViewModel toggle = new() { Output = new() };
-        _preview.Pick(toggle);
+        _preview.Pick(toggle, setVisible: false);
     }
 
     [RelayCommand]
@@ -359,7 +359,7 @@ public partial class LeftSidebarViewModel : ViewModelBase
         _selection.UnHighlightAll();
 
         ClockViewModel clock = new() { Output = new() };
-        _preview.Pick(clock);
+        _preview.Pick(clock, setVisible: false);
     }
 
     [RelayCommand]
@@ -368,6 +368,6 @@ public partial class LeftSidebarViewModel : ViewModelBase
         _selection.UnHighlightAll();
 
         ProbeViewModel probe = new() { Input = new() };
-        _preview.Pick(probe);
+        _preview.Pick(probe, setVisible: false);
     }
 }

--- a/src/Views/Main/CanvasView.axaml
+++ b/src/Views/Main/CanvasView.axaml
@@ -25,6 +25,9 @@
     VerticalAlignment="Stretch"
     HorizontalAlignment="Stretch"
     EnablePan="False"
+    PointerPressed="OnPanPointerPressed"
+    PointerMoved="OnPanPointerMoved"
+    PointerReleased="OnPanPointerReleased"
     KeyDown="OnKeyDown"
   >
     <Canvas

--- a/src/Views/Main/CanvasView.axaml.cs
+++ b/src/Views/Main/CanvasView.axaml.cs
@@ -28,6 +28,15 @@ public partial class CanvasView : UserControl
     private void OnPointerReleased(object? sender, PointerReleasedEventArgs e) =>
         (DataContext as CanvasViewModel)?.OnPointerReleased(sender, e);
 
+    private void OnPanPointerPressed(object? sender, PointerPressedEventArgs e) =>
+        (DataContext as CanvasViewModel)?.OnPanPointerPressed(sender, e);
+
+    private void OnPanPointerMoved(object? sender, PointerEventArgs e) =>
+        (DataContext as CanvasViewModel)?.OnPanPointerMoved(sender, e);
+
+    private void OnPanPointerReleased(object? sender, PointerReleasedEventArgs e) =>
+        (DataContext as CanvasViewModel)?.OnPanPointerReleased(sender, e);
+
     private void OnKeyDown(object? sender, KeyEventArgs e) =>
         (DataContext as CanvasViewModel)?.OnKeyDown(sender, e);
 }


### PR DESCRIPTION
## Short Description

- panning was previously only working with the canvas.
- also, preview `Pick()` now has the flag to set it to be immediately visible or notc.

## Checklist

After merging this pr:

- [X] Documentation will be consistent
- [X] Tests will stay updated
