### PR TITLE
fix: crash on deleting a half-baked wire

### DIFF
--- a/src/Services/Commands/DeleteCommand.cs
+++ b/src/Services/Commands/DeleteCommand.cs
@@ -354,8 +354,11 @@ public class DeleteCommand(
         {
             if (co is WireViewModel wire)
             {
-                wire.MainInput.GetModel().State = LogicState.Unknown;
-                wire.MainOutput.GetModel().State = LogicState.Unknown;
+                if (wire.MainInput is not null)
+                    wire.MainInput.GetModel().State = LogicState.Unknown;
+
+                if (wire.MainOutput is not null)
+                    wire.MainOutput.GetModel().State = LogicState.Unknown;
             }
         }
 


### PR DESCRIPTION
## Short Description

it crashed when one terminal of a wire was deleted and the wire was deleted after that. Fixed it by putting in if-statements for null checks

## Checklist

After merging this pr:

- [X] Documentation will be consistent
- [X] Tests will stay updated
